### PR TITLE
Develop

### DIFF
--- a/simple_sso/sso_client/client.py
+++ b/simple_sso/sso_client/client.py
@@ -119,7 +119,7 @@ class Client(object):
             user = User.objects.get(username=user_data['username'])
         except User.DoesNotExist:
             user = User(**user_data)
-        user.set_unusable_password()
+        # user.set_unusable_password()
         user.save()
         return user
 

--- a/simple_sso/sso_client/client.py
+++ b/simple_sso/sso_client/client.py
@@ -7,6 +7,7 @@ from django.http import HttpResponseRedirect
 from django.views.generic import View
 from itsdangerous import URLSafeTimedSerializer
 from webservices.sync import SyncConsumer
+from django.contrib.auth import get_user_model
 
 from ..compat import (
     NoReverseMatch,
@@ -16,6 +17,8 @@ from ..compat import (
     urljoin,
     urlencode,
 )
+
+User = get_user_model()
 
 
 class LoginView(View):


### PR DESCRIPTION
when i implement this code to my project, it should have to have the same auth_user_mode on settings between client and server. so if my client using custom user auth it throw this.

# Error :
django-simple-sso authorization
Manager isn't available; 'auth.User' has been swapped for 'users.User'

and the other problem is, when i tried to login to django admin it throw error that credential error with the same password, and lately i found out that the build user function set the password to unusable_password.