### PR TITLE
on client.py reverse of simple-sso-authorize was not being performed

### DIFF
--- a/simple_sso/sso_client/client.py
+++ b/simple_sso/sso_client/client.py
@@ -22,7 +22,11 @@ class LoginView(View):
         path = reverse('simple-sso-authenticate')
         redirect_to = urlunparse((scheme, netloc, path, '', query, ''))
         request_token = self.client.get_request_token(redirect_to)
-        host = urljoin(self.client.server_url, 'authorize/')
+        try:
+            authorize_url = reverse('simple-sso-authorize')
+        except NoReverseMatch:
+            authorize_url = '/authorize/'
+        host = urljoin(self.client.server_url, authorize_url)
         url = '%s?%s' % (host, urlencode([('token', request_token)]))
         return HttpResponseRedirect(url)
 


### PR DESCRIPTION
Some of the server endpoints where taken using "reverse" functionality from the client pathing. However, the path at `simple-sso-authorize` was hardcoded. I've fixed that is this commit.

This is required when a path-name change is performed, such as:

```python
# ...
sso_cli = Client()
# ... url.py ...
re_path(r'^login/sso/', include(sso_cli.get_urls())),
# ...
```