### PR TITLE
update itsdangerous restriction to ~=2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from simple_sso import __version__
 
 REQUIREMENTS = [
     'Django>=2.2',
-    'itsdangerous<1.0.0',
+    'itsdangerous~=2.0',
     'webservices[django]',
 ]
 


### PR DESCRIPTION
This may help (or even fix, dunno yet) issue #55 

Why should we upgrade itsdangerous package?
- From my point of view there is no reason not to do so, but for possible compatibility reasons. The package that should restrict it is `webservices` but does not impose any restriction
- It seems there may be other packages that may require a greater version. This may cause an incompatibility issue.
- It seems that the version itself does not matter at all while both, client & server keeps the same version installed

Why should remove any restriction on the package?
- It seems that there were some break changes in some versions.
- It may help to have some "greater" version pinning, as it may force to keep on the same version range both, client and server.

So why version `~2.0` ? (It's equivalent to `>=2.0, <3.0`)
- There is no really a great reason for this. `~1.0` may work perfectly.
- Maybe the best argument to put `~2.0` instead of `~1.0` is to try to keep that restriction as updated as we could.