### PR TITLE
[Feature] send user's groups to clients

### DIFF
--- a/simple_sso/sso_client/client.py
+++ b/simple_sso/sso_client/client.py
@@ -123,13 +123,14 @@ class Client:
             user = User(**user_data)
         user.set_unusable_password()
 
+        user.save()
+
         # Append the groups
         for group in server_groups:
             if not user.groups.filter(name=group).exists():
                 django_group, created = Group.objects.get_or_create(name=group)
                 user.groups.add(django_group)
 
-        user.save()
         return user
 
     def get_urls(self):

--- a/simple_sso/sso_server/server.py
+++ b/simple_sso/sso_server/server.py
@@ -151,6 +151,10 @@ class Server:
         raise NotImplementedError()
 
     def get_user_data(self, user, consumer, extra_data=None):
+        groups = []
+        for group in user.groups.all():
+            groups.append(group.name)
+
         user_data = {
             'username': user.username,
             'email': user.email,
@@ -159,6 +163,7 @@ class Server:
             'is_staff': False,
             'is_superuser': False,
             'is_active': user.is_active,
+            'groups': groups,
         }
         if extra_data:
             user_data['extra_data'] = self.get_user_extra_data(

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -56,6 +56,7 @@ def runtests():
     from django import setup
     from django.conf import settings
     from django.test.utils import get_runner
+    from django.core.management.utils import get_random_secret_key
 
     settings.configure(
         INSTALLED_APPS=INSTALLED_APPS,
@@ -67,6 +68,8 @@ def runtests():
         SSO_PRIVATE_KEY='private',
         SSO_PUBLIC_KEY='public',
         SSO_SERVER='http://localhost/server/',
+        DEFAULT_AUTO_FIELD='django.db.models.AutoField',
+        SECRET_KEY=get_random_secret_key()
     )
     setup()
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib.auth import get_user
 from django.contrib.auth.hashers import is_password_usable
 from django.contrib.auth.models import User
+from django.contrib.auth.models import Group
 from django.http import HttpResponseRedirect, HttpResponse
 from django.test.testcases import TestCase
 from simple_sso.sso_server.models import Token, Consumer
@@ -145,6 +146,41 @@ class SimpleSSOTests(TestCase):
             client_user = get_user(self.client)
             for key in ['username', 'email', 'first_name', 'last_name']:
                 self.assertEqual(getattr(client_user, key), getattr(server_user, key))
+
+    def test_user_groups(self):
+        """ User data update test
+
+        Tests whether sso server user data changes will be forwared to the client on the user's next login.
+
+        """
+        USERNAME = PASSWORD = 'myuser'
+        server_user = User.objects.create_user(
+            USERNAME,
+            'bob@bobster.org',
+            PASSWORD
+        )
+        test_group, created = Group.objects.get_or_create(name='SSO_SUPERADMIN')
+        server_user.groups.add(test_group)
+
+        self._get_consumer()
+
+        with UserLoginContext(self, server_user):
+            # First login
+            # try logging in and auto-follow all 302s
+            self.client.get(reverse('simple-sso-login'), follow=True)
+            # check the user
+            client_user = get_user(self.client)
+            for key in ['username', 'email', 'groups']:
+                self.assertEqual(getattr(client_user, key), getattr(server_user, key))
+
+            # Check the groups
+            client_groups = client_user.groups.all()
+            server_groups = server_user.groups.all()
+
+            # NOTE: This test does/tests anything, as DB is shared across client/server so on .all operation always groups are present without anything special.
+            # If you are reading this and know how to implement a "good" test, please, feel free to PR.
+            for group in server_groups:
+                self.assertTrue(group in client_groups)
 
     def test_custom_keygen(self):
         # WARNING: The following test uses a key generator function that is


### PR DESCRIPTION
This feature transfers group names (not priviledges) to clients.

This PR is built on top of #61 & #62