### PR TITLE
Fix Consumer name for python3/django 1.5+, fix test settings for djan…

### DIFF
--- a/simple_sso/sso_server/models.py
+++ b/simple_sso/sso_server/models.py
@@ -46,6 +46,9 @@ class Consumer(models.Model):
     def __unicode__(self):
         return self.name
 
+    def __str__(self):
+        return self.name
+
     def rotate_keys(self):
         self.secret = ConsumerSecretKeyGenerator('private_key')()
         self.key = ConsumerSecretKeyGenerator('public_key')()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -51,7 +51,6 @@ MIDDLEWARES = [
     'django.contrib.messages.middleware.MessageMiddleware',
 ]
 
-
 def runtests():
     from django import setup
     from django.conf import settings
@@ -67,6 +66,8 @@ def runtests():
         SSO_PRIVATE_KEY='private',
         SSO_PUBLIC_KEY='public',
         SSO_SERVER='http://localhost/server/',
+        SECRET_KEY='aRandomSecretKey',
+        DEFAULT_AUTO_FIELD='django.db.models.AutoField',
     )
     setup()
 


### PR DESCRIPTION
Fix of Consumer name so that it displays properly (in admin section)

2 fixes to the test settings.py to:
- add required SECRET_KEY
- add DEFAULT_AUTO_FIELD to silence spurious warnings